### PR TITLE
refactor(contracts): separate Aave initialisation into own function

### DIFF
--- a/packages/contracts/test/LiquidityPool/AaveIntegration.js
+++ b/packages/contracts/test/LiquidityPool/AaveIntegration.js
@@ -27,6 +27,8 @@ describe('Aave integration - liquidity pool', async () => {
             daiRopsten,
         ]);
 
+        await liquidityPool.initialiseAave()
+
         await dai.approve(liquidityPool.address, deposit)
         await liquidityPool.deposit(deposit);
     });

--- a/packages/contracts/test/LiquidityPool/Core.js
+++ b/packages/contracts/test/LiquidityPool/Core.js
@@ -1,25 +1,22 @@
 const { use, expect } = require('chai');
-const { solidity } = require('ethereum-waffle');
-const { utils } = require('ethers');
+const { solidity, MockProvider } = require('ethereum-waffle');
+const { bigNumberify } = require('ethers/utils');
 
 const LiquidityPool = require('../../build/LiquidityPool.json');
 const ERC20Mintable = require('../../build/ERC20Mintable.json');
 const { calculateLPTokenDelta } = require('../helpers/calculateLPTokenDelta');
 const { deployTestContract } = require('../helpers/deployTestContract');
-const { startChain } = require('../helpers/startChain');
 
 use(solidity);
-
-const { bigNumberify } = utils
 
 describe('Core liquidity pool functionality', async () => {
     let liquidityPool;
     let erc20;
     const numUserTokens = 20;
-    let user;
+    const provider = new MockProvider();
+    const [user] = provider.getWallets();
 
     beforeEach(async () => {
-        user = await startChain();
         erc20 = await deployTestContract(user, ERC20Mintable);
         liquidityPool = await deployTestContract(user, LiquidityPool, [erc20.address]);
 


### PR DESCRIPTION
This PR moves instantiation of all the links to aave contracts to an `initialiseAave`
function. This allows core `LiquidityPool` functionality to be tested in buidlerEVM without the Aave contracts