### PR TITLE
refactor(contracts): move `exercise` function to Options.sol

### DIFF
--- a/packages/contracts/contracts/CallOptions.sol
+++ b/packages/contracts/contracts/CallOptions.sol
@@ -72,16 +72,8 @@ contract CallOptions is Options {
     }
 
     /// @dev Exercise an option to claim the pool tokens
-    /// @param optionID The ID number of the option which is to be exercised
-    function exercise(uint optionID) public override returns (uint256){
-        Option storage option = options[optionID];
-
-        require(option.startTime <= now, 'Option has not been activated yet'); // solium-disable-line security/no-block-members
-        require(option.expirationTime >= now, 'Option has expired'); // solium-disable-line security/no-block-members
-        require(option.holder == msg.sender, "Wrong msg.sender");
-        require(option.state == State.Active, "Can't exercise inactive option");
-
-        option.state = State.Exercised;
+    /// @param option The option which is to be exercised
+    function _internalExercise(Option memory option) internal override {
 
         // Take ownership of paymentTokens to be paid into liquidity pool.
         require(
@@ -91,9 +83,6 @@ contract CallOptions is Options {
 
         exchangeTokens(option.strikeAmount);
         // pool.sendTokens(option.holder, option.amount);
-
-        emit Exercise(optionID, option.amount);
-        return option.amount;
     }
 
 }

--- a/packages/contracts/contracts/PutOptions.sol
+++ b/packages/contracts/contracts/PutOptions.sol
@@ -78,16 +78,8 @@ contract PutOptions is Options {
   }
 
   /// @dev Exercise an option to claim the pool tokens
-  /// @param optionID The ID number of the option which is to be exercised
-  function exercise(uint optionID) public override returns (uint amount) {
-      Option storage option = options[optionID];
-
-      require(option.startTime <= now, 'Option has not been activated yet'); // solium-disable-line security/no-block-members
-      require(option.expirationTime >= now, 'Option has expired'); // solium-disable-line security/no-block-members
-      require(option.holder == msg.sender, "Wrong msg.sender");
-      require(option.state == State.Active, "Can't exercise inactive option");
-
-      option.state = State.Expired;
+  /// @param option The option which is to be exercised
+  function _internalExercise(Option memory option) internal override {
 
       // Take ownership of paymentTokens to be paid into liquidity pool.
       require(
@@ -95,10 +87,8 @@ contract PutOptions is Options {
         "Insufficient funds"
       );
 
-      uint256 exchangedAmount = exchangeTokens(option.amount);
+      exchangeTokens(option.amount);
 
       pool.sendTokens(option.holder, option.strikeAmount);
-      emit Exercise(optionID, exchangedAmount);
-      return option.amount;
   }
 }


### PR DESCRIPTION
I've moved all the checking for option expiration, etc into `Options.sol`. `CallOptions.sol` and `PutOptions.sol` now just handle the moving of funds.