### PR TITLE
feat(contracts): deploy liquidity pools using factory

### DIFF
--- a/packages/contracts/contracts/CallOptions.sol
+++ b/packages/contracts/contracts/CallOptions.sol
@@ -1,13 +1,14 @@
 pragma solidity >=0.6.0 <0.7.0;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import { ILiquidityPoolFactory } from './interfaces/ILiquidityPoolFactory.sol';
 
 import {Options} from "./Options.sol";
 import {State, Option, OptionType} from "./Types.sol";
 
 contract CallOptions is Options {
-    constructor(IERC20 poolToken, IERC20 paymentToken)
-    Options(poolToken, paymentToken, OptionType.Call) public {}
+    constructor(IERC20 poolToken, IERC20 paymentToken, ILiquidityPoolFactory liquidityPoolFactory)
+    Options(poolToken, paymentToken, OptionType.Call, liquidityPoolFactory) public {}
 
     /**
       * @dev Create an option to buy pool tokens at the current price

--- a/packages/contracts/contracts/Options.sol
+++ b/packages/contracts/contracts/Options.sol
@@ -7,6 +7,8 @@ import { IUniswapV2Router01 } from '@uniswap/v2-periphery/contracts/interfaces/I
 
 import { LiquidityPool } from './LiquidityPool.sol';
 import { ILiquidityPool } from './interfaces/ILiquidityPool.sol';
+import { ILiquidityPoolFactory } from './interfaces/ILiquidityPoolFactory.sol';
+
 
 import { IOptions } from './interfaces/IOptions.sol';
 
@@ -42,8 +44,8 @@ abstract contract Options is IOptions, Ownable {
     function _internalExercise(Option memory option, uint optionID) internal virtual;
 
     
-    constructor(IERC20 poolToken, IERC20 _paymentToken, OptionType t) public {
-        pool = new LiquidityPool(poolToken);
+    constructor(IERC20 poolToken, IERC20 _paymentToken, OptionType t, ILiquidityPoolFactory liquidityPoolFactory) public {
+        pool = liquidityPoolFactory.createPool(poolToken);
         paymentToken= _paymentToken;
         optionType = t;
 

--- a/packages/contracts/contracts/PutOptions.sol
+++ b/packages/contracts/contracts/PutOptions.sol
@@ -1,6 +1,7 @@
 pragma solidity >=0.6.0 <0.7.0;
 
 import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import { ILiquidityPoolFactory } from './interfaces/ILiquidityPoolFactory.sol';
 
 import {Options} from "./Options.sol";
 import {State, Option, OptionType} from "./Types.sol";
@@ -12,8 +13,8 @@ import {State, Option, OptionType} from "./Types.sol";
  * Copyright 2020 Tom Waite, Tom French
  */
 contract PutOptions is Options {
-  constructor(IERC20 poolToken, IERC20 paymentToken)
-    Options(poolToken, paymentToken, OptionType.Put) public {}
+  constructor(IERC20 poolToken, IERC20 paymentToken, ILiquidityPoolFactory liquidityPoolFactory)
+    Options(poolToken, paymentToken, OptionType.Put, liquidityPoolFactory) public {}
 
 
   /**

--- a/packages/contracts/contracts/factories/LiquidityPoolFactory.sol
+++ b/packages/contracts/contracts/factories/LiquidityPoolFactory.sol
@@ -1,0 +1,27 @@
+pragma solidity >=0.6.0 <0.7.0;
+
+import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {IUniswapV2Factory} from '@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol';
+import {ILiquidityPoolFactory} from '../interfaces/ILiquidityPoolFactory.sol';
+
+import {LiquidityPool} from '../LiquidityPool.sol';
+import { ILiquidityPool } from '../interfaces/ILiquidityPool.sol';
+
+
+contract LiquidityPoolFactory is ILiquidityPoolFactory {
+
+    event PoolCreated(address indexed poolToken, address pool);
+
+    function createPool(IERC20 poolToken) external override returns (ILiquidityPool) {
+        require(address(poolToken) != address(0), 'LiquidityPoolFactory: ZERO_ADDRESS');
+
+        // Deploy new options contract
+        LiquidityPool pool = new LiquidityPool(IERC20(poolToken));
+
+        // Transfer ownership to options contract
+        pool.transferOwnership(msg.sender);
+
+        emit PoolCreated(address(poolToken), address(pool));
+        return pool;
+    }
+}

--- a/packages/contracts/contracts/interfaces/ILiquidityPoolFactory.sol
+++ b/packages/contracts/contracts/interfaces/ILiquidityPoolFactory.sol
@@ -1,0 +1,10 @@
+pragma solidity >=0.6.0 <0.7.0;
+
+import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import { ILiquidityPool } from './ILiquidityPool.sol';
+
+interface ILiquidityPoolFactory {
+    event PairCreated(address indexed poolToken, address pair);
+
+    function createPool(IERC20 poolToken) external returns (ILiquidityPool pool);
+}

--- a/packages/contracts/test/helpers/fixtures.js
+++ b/packages/contracts/test/helpers/fixtures.js
@@ -11,6 +11,7 @@ const ERC20Mintable = require('../../build/ERC20Mintable.json');
 
 const CallOptions = require('../../build/CallOptions.json');
 const LiquidityPool = require('../../build/LiquidityPool.json');
+const LiquidityPoolFactory = require('../../build/LiquidityPoolFactory.json');
 
 function expandTo18Decimals(n) {
     return bigNumberify(n).mul(bigNumberify(10).pow(18));
@@ -101,11 +102,26 @@ async function v2Fixture(provider, [wallet]) {
     };
 }
 
+async function liquidityPoolFactoryFixture(provider, [wallet]) {
+    const liquidityPoolFactory = await deployContract(
+        wallet,
+        LiquidityPoolFactory,
+        [],
+        overrides
+    );
+    return { liquidityPoolFactory };
+}
+
 // Fixture that sets up the option, liquidityPool and Uniswap V2
 async function generalTestFixture(provider, [liquidityProvider, optionsBuyer]) {
     const { token0, token1, router, pair } = await v2Fixture(provider, [
         liquidityProvider,
     ]);
+
+    const { liquidityPoolFactory } = await liquidityPoolFactoryFixture(
+        provider,
+        [liquidityProvider]
+    );
 
     const poolToken = token0;
     const paymentToken = token1;
@@ -113,7 +129,7 @@ async function generalTestFixture(provider, [liquidityProvider, optionsBuyer]) {
     let optionsContract = await deployContract(
         liquidityProvider,
         CallOptions,
-        [poolToken.address, paymentToken.address],
+        [poolToken.address, paymentToken.address, liquidityPoolFactory.address],
         overrides
     );
     await optionsContract.setUniswapRouter(router.address);


### PR DESCRIPTION
This PR is in preparation for deploying options through an options factory.

If we try to build an options factory as of now, its bytecode is too large for deployment due to it containing the bytecode of `CallOptions`/`LiquidityPool`/`ERC20`, etc. Through using a factory to deploy the Liquidity pool we reduce the bytecode size of the options factory.