### PR TITLE
Standardise revert error messages

### DIFF
--- a/packages/contracts/contracts/LiquidityPool.sol
+++ b/packages/contracts/contracts/LiquidityPool.sol
@@ -57,7 +57,7 @@ contract LiquidityPool is ILiquidityPool, ERC20, Ownable {
     * @param amount Number of ERC20 tokens to transfer to pool
      */
     function deposit(uint256 amount) public override {
-        require(amount != uint256(0), 'Pool/can not deposit 0');
+        require(amount != uint256(0), 'Pool: can not deposit 0');
 
         uint256 numLPTokensToMint;
         if (totalSupply() == 0) {
@@ -70,7 +70,7 @@ contract LiquidityPool is ILiquidityPool, ERC20, Ownable {
 
         require(
             linkedToken.transferFrom(msg.sender, address(this), amount),
-            'Pool/insufficient user funds to deposit'
+            'Pool: insufficient user funds to deposit'
         );
 
         emit Deposit(msg.sender, address(this), amount);
@@ -81,7 +81,7 @@ contract LiquidityPool is ILiquidityPool, ERC20, Ownable {
     * aTokens in return 
      */
     function transferToAave(uint256 transferAmount) public override onlyOwner {
-        require(aaveInitialised, "Pool/aave integration is not initialised");
+        require(aaveInitialised, "Pool: aave integration is not initialised");
         
         // TODO: investigate why this doesn't work for approvals set to transferAmount rather than a very large number
         linkedToken.approve(aaveProvider.getLendingPoolCore(), uint256(0x1f));        
@@ -94,21 +94,21 @@ contract LiquidityPool is ILiquidityPool, ERC20, Ownable {
     * @param amount Number of ERC20 tokens to withdraw 
      */
     function withdraw(uint256 amount) public override {
-        require(amount != uint256(0), 'Pool/can not withdraw 0');
-        require(totalSupply() > uint256(0), 'Pool/no LP tokens minted');
+        require(amount != uint256(0), 'Pool: can not withdraw 0');
+        require(totalSupply() > uint256(0), 'Pool: no LP tokens minted');
 
         uint256 poolERC20Balance = getPoolERC20Balance();
-        require(amount <= poolERC20Balance, 'Pool/insufficient pool balance');
+        require(amount <= poolERC20Balance, 'Pool: insufficient pool balance');
 
         uint256 numLPTokensToBurn = (amount.mul(totalSupply())).div(getPoolERC20Balance());
         
-        require(balanceOf(msg.sender) != uint256(0), 'Pool/user has no LP tokens');
-        require(numLPTokensToBurn <= balanceOf(msg.sender), 'Pool/not enough LP tokens to burn');
+        require(balanceOf(msg.sender) != uint256(0), 'Pool: user has no LP tokens');
+        require(numLPTokensToBurn <= balanceOf(msg.sender), 'Pool: not enough LP tokens to burn');
         _burn(msg.sender, numLPTokensToBurn);
 
         require(
             linkedToken.transfer(msg.sender, amount),
-            'Pool/insufficient user funds to withdraw'
+            'Pool: insufficient user funds to withdraw'
         );
 
         emit Withdraw(msg.sender, address(this), amount);
@@ -119,7 +119,7 @@ contract LiquidityPool is ILiquidityPool, ERC20, Ownable {
     * Protected by onlyOwner
      */
     function withdrawFromAave(uint256 redeemAmount) public override onlyOwner {
-        require(aaveInitialised, "Pool/aave integration is not initialised");
+        require(aaveInitialised, "Pool: aave integration is not initialised");
         aTokenInstance.redeem(redeemAmount);
         emit RedeemAave(owner(), redeemAmount);
     }
@@ -129,9 +129,9 @@ contract LiquidityPool is ILiquidityPool, ERC20, Ownable {
     * Protected by onlyOwner
      */
     function transferATokens(uint256 amount, address recipient) public override onlyOwner {
-        require(aaveInitialised, "Pool/aave integration is not initialised");
-        require(recipient != address(0x0));
-        require(amount != uint256(0));
+        require(aaveInitialised, "Pool: aave integration is not initialised");
+        require(recipient != address(0x0), "Pool: transfer to the zero address");
+        require(amount != uint256(0), "Pool: zero value transfer");
 
         aTokenInstance.transfer(recipient, amount);
     }
@@ -147,7 +147,7 @@ contract LiquidityPool is ILiquidityPool, ERC20, Ownable {
     * @dev Get the total number of aDAI tokens deposited into the liquidity pool
      */
     function getPoolATokenBalance() public view override returns (uint256) {
-        require(aaveInitialised, "Pool/aave integration is not initialised");
+        require(aaveInitialised, "Pool: aave integration is not initialised");
         return aTokenInstance.balanceOf(address(this));
     }
 
@@ -167,6 +167,6 @@ contract LiquidityPool is ILiquidityPool, ERC20, Ownable {
     function sendTokens(address recipient, uint256 transferAmount) external override onlyOwner {
         // TODO: unlock the same tokens
         // unlock(amount)
-        require(IERC20(linkedToken).transfer(recipient, transferAmount), "Transfer of pool tokens failed");
+        require(IERC20(linkedToken).transfer(recipient, transferAmount), "Pool: Transfer of pool tokens failed");
     }
 }

--- a/packages/contracts/contracts/Options.sol
+++ b/packages/contracts/contracts/Options.sol
@@ -82,10 +82,10 @@ abstract contract Options is IOptions, Ownable {
     function exercise(uint optionID) public returns (uint256){
         Option storage option = options[optionID];
 
-        require(option.startTime <= now, 'Option has not been activated yet'); // solium-disable-line security/no-block-members
-        require(option.expirationTime >= now, 'Option has expired'); // solium-disable-line security/no-block-members
-        require(option.holder == msg.sender, "Wrong msg.sender");
-        require(option.state == State.Active, "Can't exercise inactive option");
+        require(option.startTime <= now, 'Options: Option has not been activated yet'); // solium-disable-line security/no-block-members
+        require(option.expirationTime >= now, 'Options: Option has expired'); // solium-disable-line security/no-block-members
+        require(option.holder == msg.sender, "Options: Wrong msg.sender");
+        require(option.state == State.Active, "Options: Can't exercise inactive option");
 
         option.state = State.Exercised;
 
@@ -113,8 +113,8 @@ abstract contract Options is IOptions, Ownable {
         Option storage option = options[optionID];
 
         // Ensure that option is eligible to be nullified
-        require(option.expirationTime < now, "Option has not expired yet");
-        require(option.state == State.Active, "Option is not active");
+        require(option.expirationTime < now, "Options: Option has not expired yet");
+        require(option.state == State.Active, "Options: Option is not active");
 
         option.state = State.Expired;
 
@@ -131,7 +131,7 @@ abstract contract Options is IOptions, Ownable {
     /// the option exercise to the exchange
     /// @return exchangedAmount The amount of pool tokens sent to the pool
     function exchangeTokens(uint inputAmount, uint optionId) internal returns (uint) {
-      require(inputAmount != uint(0), 'Options/ Swapping 0 tokens');
+      require(inputAmount != uint(0), 'Options: Swapping 0 tokens');
       paymentToken.approve(address(uniswapRouter), inputAmount);
 
       uint deadline = now + 2 minutes;

--- a/packages/contracts/test/LiquidityPool/Core.js
+++ b/packages/contracts/test/LiquidityPool/Core.js
@@ -53,7 +53,7 @@ describe('Core liquidity pool functionality', async () => {
 
             it('should reject zero deposit', async () => {
                 await expect(liquidityPool.deposit('0')).to.be.revertedWith(
-                    'Pool/can not deposit 0'
+                    'Pool: can not deposit 0'
                 );
             });
 
@@ -100,7 +100,7 @@ describe('Core liquidity pool functionality', async () => {
 
             it('should reject zero deposit', async () => {
                 await expect(liquidityPool.deposit('0')).to.be.revertedWith(
-                    'Pool/can not deposit 0'
+                    'Pool: can not deposit 0'
                 );
             });
 
@@ -161,7 +161,7 @@ describe('Core liquidity pool functionality', async () => {
 
         it('should reject zero withdrawal', async () => {
             await expect(liquidityPool.withdraw('0')).to.be.revertedWith(
-                'Pool/can not withdraw 0'
+                'Pool: can not withdraw 0'
             );
         });
 


### PR DESCRIPTION
`require` error statements are now all prepended with "[contract identifier]:"

closes #14