### PR TITLE
feat(contracts): add OptionsFactory contract

### DIFF
--- a/packages/contracts/contracts/factories/OptionsFactory.sol
+++ b/packages/contracts/contracts/factories/OptionsFactory.sol
@@ -1,0 +1,45 @@
+pragma solidity >=0.6.0 <0.7.0;
+
+import { IERC20 } from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {IUniswapV2Factory} from '@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol';
+import {ILiquidityPoolFactory} from '../interfaces/ILiquidityPoolFactory.sol';
+import {IOptionsFactory} from '../interfaces/IOptionsFactory.sol';
+import {Options} from '../Options.sol';
+import {IOptions} from '../interfaces/IOptions.sol';
+
+contract OptionsFactory is IOptionsFactory {
+
+    IUniswapV2Factory uniswapFactory;
+    ILiquidityPoolFactory liquidityPoolFactory;
+    mapping(address => mapping(address => address)) public override getMarket;
+    address[] public override allMarkets;
+
+    event MarketCreated(address indexed poolToken, address indexed paymentToken, address market, uint);
+
+    constructor(IUniswapV2Factory _uniswapFactory, ILiquidityPoolFactory _liquidityPoolFactory) public {
+        uniswapFactory = _uniswapFactory;
+        liquidityPoolFactory = _liquidityPoolFactory;
+    }
+
+    function allMarketsLength() external view override returns (uint) {
+        return allMarkets.length;
+    }
+
+    function createMarket(address poolToken, address paymentToken) external override returns (address) {
+        require(poolToken != paymentToken, 'OptionsFactory: IDENTICAL_ADDRESSES');
+        require(poolToken != address(0), 'OptionsFactory: ZERO_ADDRESS');
+        require(paymentToken != address(0), 'OptionsFactory: ZERO_ADDRESS');
+        require(getMarket[poolToken][paymentToken] == address(0), 'OptionsFactory: MARKET_EXISTS');
+        require(uniswapFactory.getPair(poolToken,paymentToken) != address(0), 'OptionsFactory: Uniswap pair does not exist');
+
+        // Deploy new options contract
+        bytes32 salt = keccak256(abi.encode(poolToken, paymentToken));
+        Options market = new Options{salt: salt}(IERC20(poolToken), IERC20(paymentToken), liquidityPoolFactory);
+
+        // Store options contract address
+        getMarket[poolToken][paymentToken] = address(market);
+        allMarkets.push(address(market));
+        emit MarketCreated(poolToken, paymentToken, address(market), allMarkets.length);
+        return address(market);
+    }
+}

--- a/packages/contracts/contracts/interfaces/IOptionsFactory.sol
+++ b/packages/contracts/contracts/interfaces/IOptionsFactory.sol
@@ -1,0 +1,11 @@
+pragma solidity >=0.6.0 <0.7.0;
+
+interface IOptionsFactory {
+    event MarketCreated(address indexed poolToken, address indexed paymentToken, address market, uint);
+
+    function getMarket(address poolToken, address paymentToken) external view returns (address market);
+    function allMarkets(uint) external view returns (address market);
+    function allMarketsLength() external view returns (uint);
+
+    function createMarket(address poolToken, address paymentToken) external returns (address market);
+}

--- a/packages/contracts/test/OptionsFactory/OptionsFactory.js
+++ b/packages/contracts/test/OptionsFactory/OptionsFactory.js
@@ -1,0 +1,92 @@
+const { expect, use } = require('chai');
+const { Contract } = require('ethers');
+const { bigNumberify } = require('ethers/utils');
+const {
+    solidity,
+    MockProvider,
+    createFixtureLoader,
+} = require('ethereum-waffle');
+const { optionFactoryFixture } = require('../helpers/fixtures');
+
+const Options = require('../../build/Options.json');
+
+const { getMarketAddress } = require('../helpers/utilities');
+
+use(solidity);
+
+const overrides = {
+    gasLimit: 9999999,
+};
+
+describe('OptionsFactory', () => {
+    const provider = new MockProvider(overrides);
+    const [wallet, other] = provider.getWallets();
+    const loadFixture = createFixtureLoader(provider, [wallet, other]);
+
+    let factory;
+    let tokenAddresses;
+    let poolFactory;
+    beforeEach(async () => {
+        const {
+            token0,
+            token1,
+            optionsFactory,
+            liquidityPoolFactory,
+        } = await loadFixture(optionFactoryFixture);
+        tokenAddresses = [token0.address, token1.address];
+        factory = optionsFactory;
+        poolFactory = liquidityPoolFactory;
+    });
+
+    it('allMarketsLength', async () => {
+        expect(await factory.allMarketsLength()).to.eq(0);
+    });
+
+    async function createMarket(tokens) {
+        const bytecode = `0x${Options.evm.bytecode.object}`;
+        const create2Address = getMarketAddress(
+            factory.address,
+            tokens,
+            poolFactory.address,
+            bytecode
+        );
+        await expect(factory.createMarket(...tokens))
+            .to.emit(factory, 'MarketCreated')
+            .withArgs(
+                tokenAddresses[0],
+                tokenAddresses[1],
+                create2Address,
+                bigNumberify(1)
+            );
+
+        await expect(factory.createMarket(...tokens)).to.be.revertedWith(
+            'OptionsFactory: MARKET_EXISTS'
+        );
+
+        expect(await factory.getMarket(...tokens)).to.eq(create2Address);
+        expect(await factory.allMarkets(0)).to.eq(create2Address);
+        expect(await factory.allMarketsLength()).to.eq(1);
+
+        const optionsContract = new Contract(
+            create2Address,
+            JSON.stringify(Options.abi),
+            provider
+        );
+        expect(await optionsContract.poolToken()).to.eq(tokenAddresses[0]);
+        expect(await optionsContract.paymentToken()).to.eq(tokenAddresses[1]);
+    }
+
+    it('createMarket', async () => {
+        await createMarket(tokenAddresses);
+    });
+
+    // it('createMarket:reverse', async () => {
+    //     await createMarket(tokenAddresses.slice().reverse());
+    // });
+
+    it('createMarket:gas', async () => {
+        const tx = await factory.createMarket(...tokenAddresses);
+        const receipt = await tx.wait();
+        expect(receipt.gasUsed).to.eq(5478217);
+    });
+});

--- a/packages/contracts/test/helpers/utilities.js
+++ b/packages/contracts/test/helpers/utilities.js
@@ -1,0 +1,38 @@
+const {
+    bigNumberify,
+    keccak256,
+    solidityPack,
+    getCreate2Address,
+} = require('ethers/utils');
+
+function expandTo18Decimals(n) {
+    return bigNumberify(n).mul(bigNumberify(10).pow(18));
+}
+
+function getMarketAddress(
+    factoryAddress,
+    [poolToken, paymentToken],
+    poolFactory,
+    bytecode
+) {
+    const salt = keccak256(
+        solidityPack(['address', 'address'], [poolToken, paymentToken])
+    );
+    const initCodeHash = keccak256(
+        solidityPack(
+            ['bytes', 'address', 'address', 'address'],
+            [bytecode, poolToken, paymentToken, poolFactory]
+        )
+    );
+
+    return getCreate2Address({
+        from: factoryAddress,
+        salt,
+        initCodeHash,
+    });
+}
+
+module.exports = {
+    expandTo18Decimals,
+    getMarketAddress,
+};


### PR DESCRIPTION
The test to calculate the `create2` address offchain is still failing mysteriously but for the time being we can just query on-chain for a given market address