### PR TITLE
refactor(react-app): refactor table of owned options into components

### DIFF
--- a/packages/react-app/src/components/OptionTable/OptionRow.tsx
+++ b/packages/react-app/src/components/OptionTable/OptionRow.tsx
@@ -1,0 +1,55 @@
+import React, { ReactElement } from 'react';
+import moment from 'moment';
+import Button from '@material-ui/core/Button';
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+
+enum OptionState {
+  Active = 0,
+  Exercised,
+  Expired,
+}
+
+const OptionRow = ({
+  option,
+  approveFunds,
+  exerciseOption,
+}: {
+  option: any;
+  approveFunds: Function;
+  exerciseOption: Function;
+}): ReactElement => {
+  return (
+    <TableRow key={option.optionId}>
+      <TableCell align="right">{option.optionId}</TableCell>
+      <TableCell align="right">{option.amount.toString()}</TableCell>
+      <TableCell align="right">{option.strikeAmount.toString()}</TableCell>
+      <TableCell align="right">{moment.unix(option.startTime).format('DD-MM-YYYY HH:mm')}</TableCell>
+      <TableCell align="right">{moment.unix(option.expirationTime).format('DD-MM-YYYY HH:mm')}</TableCell>
+      <TableCell align="right">{OptionState[option.state]}</TableCell>
+      <TableCell align="right">
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={(): void => approveFunds()}
+          disabled={option.state !== OptionState.Active}
+        >
+          Approve
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={(): void => {
+            console.log('optionId: ', option.optionId);
+            return exerciseOption();
+          }}
+          disabled={option.state !== OptionState.Active}
+        >
+          Exercise Option
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default OptionRow;

--- a/packages/react-app/src/components/OptionTable/OptionRow.tsx
+++ b/packages/react-app/src/components/OptionTable/OptionRow.tsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import Button from '@material-ui/core/Button';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
+import { Option } from '../../types/types';
 
 enum OptionState {
   Active = 0,
@@ -15,24 +16,25 @@ const OptionRow = ({
   approveFunds,
   exerciseOption,
 }: {
-  option: any;
+  option: Option;
   approveFunds: Function;
   exerciseOption: Function;
 }): ReactElement => {
+  const { id, amount, strikeAmount, startTime, expirationTime, state } = option;
   return (
-    <TableRow key={option.optionId}>
-      <TableCell align="right">{option.optionId}</TableCell>
-      <TableCell align="right">{option.amount.toString()}</TableCell>
-      <TableCell align="right">{option.strikeAmount.toString()}</TableCell>
-      <TableCell align="right">{moment.unix(option.startTime).format('DD-MM-YYYY HH:mm')}</TableCell>
-      <TableCell align="right">{moment.unix(option.expirationTime).format('DD-MM-YYYY HH:mm')}</TableCell>
-      <TableCell align="right">{OptionState[option.state]}</TableCell>
+    <TableRow key={id}>
+      <TableCell align="right">{id}</TableCell>
+      <TableCell align="right">{amount.toString()}</TableCell>
+      <TableCell align="right">{strikeAmount.toString()}</TableCell>
+      <TableCell align="right">{moment.unix(startTime.toNumber()).format('DD-MM-YYYY HH:mm')}</TableCell>
+      <TableCell align="right">{moment.unix(expirationTime.toNumber()).format('DD-MM-YYYY HH:mm')}</TableCell>
+      <TableCell align="right">{OptionState[state]}</TableCell>
       <TableCell align="right">
         <Button
           variant="contained"
           color="primary"
           onClick={(): void => approveFunds()}
-          disabled={option.state !== OptionState.Active}
+          disabled={state !== OptionState.Active}
         >
           Approve
         </Button>
@@ -40,10 +42,10 @@ const OptionRow = ({
           variant="contained"
           color="primary"
           onClick={(): void => {
-            console.log('optionId: ', option.optionId);
+            console.log('optionId: ', id);
             return exerciseOption();
           }}
-          disabled={option.state !== OptionState.Active}
+          disabled={state !== OptionState.Active}
         >
           Exercise Option
         </Button>

--- a/packages/react-app/src/components/OptionTable/OptionTable.tsx
+++ b/packages/react-app/src/components/OptionTable/OptionTable.tsx
@@ -11,7 +11,7 @@ import OptionRow from './OptionRow';
 
 import IERC20 from '../../abis/IERC20.json';
 import { useWalletProvider } from '../../contexts/OnboardContext';
-import { Address } from '../../types/types';
+import { Address, Option } from '../../types/types';
 
 const OptionTable = ({
   paymentToken,
@@ -20,7 +20,7 @@ const OptionTable = ({
 }: {
   paymentToken: Address;
   optionContract: Contract;
-  options: any;
+  options: Array<Option>;
 }): ReactElement => {
   const provider = useWalletProvider();
 
@@ -48,7 +48,7 @@ const OptionTable = ({
         </TableRow>
       </TableHead>
       <TableBody>
-        {options.map((option: any) => (
+        {options.map((option: Option) => (
           <OptionRow
             key={option.id}
             option={option}

--- a/packages/react-app/src/components/OptionTable/OptionTable.tsx
+++ b/packages/react-app/src/components/OptionTable/OptionTable.tsx
@@ -1,0 +1,64 @@
+import React, { ReactElement } from 'react';
+import { Contract } from 'ethers';
+import { Web3Provider } from 'ethers/providers';
+
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import OptionRow from './OptionRow';
+
+import IERC20 from '../../abis/IERC20.json';
+import { useWalletProvider } from '../../contexts/OnboardContext';
+import { Address } from '../../types/types';
+
+const OptionTable = ({
+  paymentToken,
+  optionContract,
+  options,
+}: {
+  paymentToken: Address;
+  optionContract: Contract;
+  options: any;
+}): ReactElement => {
+  const provider = useWalletProvider();
+
+  const approveFunds = (amount: string): void => {
+    const signer = new Web3Provider(provider).getSigner();
+    const token = new Contract(paymentToken, IERC20.abi, signer);
+    if (optionContract) token.approve(optionContract.address, amount);
+  };
+
+  const exerciseOption = (optionId: string): void => {
+    optionContract.exercise(optionId);
+  };
+
+  return (
+    <Table>
+      <TableHead>
+        <TableRow>
+          <TableCell align="right">Option ID</TableCell>
+          <TableCell align="right">Amount</TableCell>
+          <TableCell align="right">Strike Amount</TableCell>
+          <TableCell align="right">Start Time</TableCell>
+          <TableCell align="right">Expiry Time</TableCell>
+          <TableCell align="right">Option State</TableCell>
+          <TableCell align="right"></TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {options.map((option: any) => (
+          <OptionRow
+            key={option.id}
+            option={option}
+            approveFunds={(): void => approveFunds(option.amount.mul(10).toString())}
+            exerciseOption={(): void => exerciseOption(option.id)}
+          />
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
+export default OptionTable;

--- a/packages/react-app/src/pages/BuyOptionsPage.tsx
+++ b/packages/react-app/src/pages/BuyOptionsPage.tsx
@@ -9,7 +9,7 @@ import { Web3Provider } from 'ethers/providers';
 import IERC20 from '../abis/IERC20.json';
 
 import getOptionContract from '../utils/getOptionContract';
-import { useWallet } from '../contexts/OnboardContext';
+import { useWalletProvider } from '../contexts/OnboardContext';
 import tokens from '../constants/tokens';
 
 const useStyles = makeStyles((theme) => ({
@@ -51,7 +51,7 @@ const getFees = async (optionContract: Contract, amount: string, optionType: Opt
 
 const BuyOptionsPage = (props: any): ReactElement | null => {
   const classes = useStyles();
-  const wallet = useWallet();
+  const provider = useWalletProvider();
 
   const [optionContract, setOptionContract] = useState<Contract>();
   const [optionType, setOptionType] = useState<OptionType>(OptionType.Put);
@@ -61,11 +61,11 @@ const BuyOptionsPage = (props: any): ReactElement | null => {
 
   useEffect(() => {
     async function getMarketContract(): Promise<void> {
-      if (props.factoryAddress && wallet.provider) {
-        const signer = new Web3Provider(wallet.provider).getSigner();
+      if (props.factoryAddress && provider) {
+        const ethersProvider = new Web3Provider(provider);
         try {
           const optionMarket = await getOptionContract(
-            signer,
+            ethersProvider,
             props.factoryAddress,
             props.poolToken,
             props.paymentToken,
@@ -79,7 +79,7 @@ const BuyOptionsPage = (props: any): ReactElement | null => {
       }
     }
     getMarketContract();
-  }, [wallet, props.factoryAddress, props.poolToken, props.paymentToken]);
+  }, [provider, props.factoryAddress, props.poolToken, props.paymentToken]);
 
   useEffect(() => {
     if (optionContract) {
@@ -90,7 +90,7 @@ const BuyOptionsPage = (props: any): ReactElement | null => {
   }, [optionContract, amount, optionType]);
 
   const approveFunds = (approvalAmount: string): void => {
-    const signer = new Web3Provider(wallet.provider).getSigner();
+    const signer = new Web3Provider(provider).getSigner();
     const token = new Contract(props.paymentToken, IERC20.abi, signer);
     if (optionContract) token.approve(optionContract.address, approvalAmount);
   };

--- a/packages/react-app/src/pages/ExerciseOptionsPage.tsx
+++ b/packages/react-app/src/pages/ExerciseOptionsPage.tsx
@@ -69,7 +69,7 @@ const ExerciseOptionsPage = (props: any): ReactElement => {
         const etherProvider = new Web3Provider(provider);
         try {
           const optionMarket = await getOptionContract(
-            etherProvider.getSigner(),
+            etherProvider,
             props.factoryAddress,
             props.poolToken,
             props.paymentToken,

--- a/packages/react-app/src/pages/ExerciseOptionsPage.tsx
+++ b/packages/react-app/src/pages/ExerciseOptionsPage.tsx
@@ -1,21 +1,15 @@
 import React, { ReactElement, useEffect, useState } from 'react';
-import moment from 'moment';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
-import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
 
 import { ethers, Contract } from 'ethers';
 import { Web3Provider } from 'ethers/providers';
+import { CircularProgress } from '@material-ui/core';
+import OptionsTable from '../components/OptionTable/OptionTable';
 import Options from '../abis/Options.json';
-import IERC20 from '../abis/IERC20.json';
 
-import { useAddress, useWallet } from '../contexts/OnboardContext';
+import { useAddress, useWalletProvider } from '../contexts/OnboardContext';
 
 import getOptionContract from '../utils/getOptionContract';
 
@@ -63,18 +57,18 @@ const getOptions = async (provider: Web3Provider, optionMarket: Contract, filter
 const ExerciseOptionsPage = (props: any): ReactElement => {
   const classes = useStyles();
   const userAddress = useAddress();
-  const wallet = useWallet();
+  const provider = useWalletProvider();
 
   const [options, setOptions] = useState<Array<any>>([]);
   const [optionContract, setOptionContract] = useState<Contract | null>();
 
   useEffect(() => {
     async function getPoolContract(): Promise<void> {
-      if (props.factoryAddress && wallet.provider) {
-        const provider = new Web3Provider(wallet.provider);
+      if (props.factoryAddress && provider) {
+        const etherProvider = new Web3Provider(provider);
         try {
           const optionMarket = await getOptionContract(
-            provider.getSigner(),
+            etherProvider.getSigner(),
             props.factoryAddress,
             props.poolToken,
             props.paymentToken,
@@ -89,7 +83,7 @@ const ExerciseOptionsPage = (props: any): ReactElement => {
           };
           console.log('finding logs');
 
-          getOptions(provider, optionMarket, filter).then((newoptions) =>
+          getOptions(etherProvider, optionMarket, filter).then((newoptions) =>
             setOptions(
               newoptions.filter((option: any) => {
                 return option.state === 0;
@@ -103,62 +97,23 @@ const ExerciseOptionsPage = (props: any): ReactElement => {
       }
     }
     getPoolContract();
-  }, [wallet, userAddress, props.factoryAddress, props.poolToken, props.paymentToken]);
+  }, [provider, userAddress, props.factoryAddress, props.poolToken, props.paymentToken]);
 
-  const approveFunds = (amount: string): void => {
-    const signer = new Web3Provider(wallet.provider).getSigner();
-    const token = new Contract(props.paymentToken, IERC20.abi, signer);
-    if (optionContract) token.approve(optionContract.address, amount);
-  };
+  if (!optionContract) {
+    return (
+      <Paper className={`${classes.pageElement} ${classes.paper}`}>
+        <Grid container direction="row" justify="space-around" spacing={3}>
+          <CircularProgress />
+        </Grid>
+      </Paper>
+    );
+  }
 
-  const exerciseOption = (optionId: string): void => {
-    if (optionContract) optionContract.exercise(optionId);
-  };
-
+  console.log(options);
   return (
     <Paper className={`${classes.pageElement} ${classes.paper}`}>
       <Grid container direction="row" justify="space-around" spacing={3}>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell align="right">OptionId</TableCell>
-              <TableCell align="right">Start time</TableCell>
-              <TableCell align="right">Expiry time</TableCell>
-              <TableCell align="right"></TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {options.length &&
-              options.map((option: any) => {
-                return (
-                  <TableRow key={option.optionId}>
-                    <TableCell align="right">{option.optionId}</TableCell>
-                    <TableCell align="right">{moment.unix(option.startTime).format('DD-MM-YYYY HH:mm')}</TableCell>
-                    <TableCell align="right">{moment.unix(option.expirationTime).format('DD-MM-YYYY HH:mm')}</TableCell>
-                    <TableCell align="right">
-                      <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={(): void => approveFunds(option.amount.mul(10).toString())}
-                      >
-                        Approve
-                      </Button>
-                      <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={(): void => {
-                          console.log('optionId: ', option.optionId);
-                          return exerciseOption(option.optionId);
-                        }}
-                      >
-                        Exercise Option
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-          </TableBody>
-        </Table>
+        <OptionsTable paymentToken={props.paymentToken} optionContract={optionContract} options={options} />
       </Grid>
     </Paper>
   );

--- a/packages/react-app/src/types/types.ts
+++ b/packages/react-app/src/types/types.ts
@@ -1,3 +1,5 @@
+import { BigNumber } from 'ethers/utils';
+
 export type Address = string;
 
 export type Hash = string;
@@ -9,3 +11,18 @@ export type Hash = string;
 //     web3: any;
 //   }
 // }
+
+export type OptionType = 0 | 1;
+export type OptionState = 0 | 1 | 2;
+
+export type Option = {
+  id: string;
+  amount: BigNumber;
+  expirationTime: BigNumber;
+  holder: Address;
+  optionType: OptionType;
+  premium: BigNumber;
+  startTime: BigNumber;
+  state: OptionState;
+  strikeAmount: BigNumber;
+};

--- a/packages/react-app/src/utils/getOptionContract.ts
+++ b/packages/react-app/src/utils/getOptionContract.ts
@@ -1,12 +1,13 @@
 import { Contract } from 'ethers';
 
+import { Provider } from 'ethers/providers';
 import OptionsFactory from '../abis/OptionsFactory.json';
 import Options from '../abis/Options.json';
 
 import { Address } from '../types/types';
 
 const getOptionContract = async (
-  provider: any,
+  provider: Provider,
   factoryAddress: Address,
   poolToken: Address,
   paymentToken: Address,

--- a/packages/react-app/src/utils/getOptionContract.ts
+++ b/packages/react-app/src/utils/getOptionContract.ts
@@ -1,20 +1,20 @@
 import { Contract } from 'ethers';
 
-import { Provider } from 'ethers/providers';
+import { JsonRpcProvider } from 'ethers/providers';
 import OptionsFactory from '../abis/OptionsFactory.json';
 import Options from '../abis/Options.json';
 
 import { Address } from '../types/types';
 
 const getOptionContract = async (
-  provider: Provider,
+  provider: JsonRpcProvider,
   factoryAddress: Address,
   poolToken: Address,
   paymentToken: Address,
 ): Promise<Contract> => {
   const optionsFactory = new Contract(factoryAddress, OptionsFactory.abi, provider);
   const optionMarketAddress = await optionsFactory.getMarket(poolToken, paymentToken);
-  const optionMarket = new Contract(optionMarketAddress as string, Options.abi, provider);
+  const optionMarket = new Contract(optionMarketAddress as string, Options.abi, provider.getSigner());
   return optionMarket;
 };
 


### PR DESCRIPTION
I've refactored the `ExerciseOptionsPage` so that there is a separate component for the table of options which the user owns. 

This also adds the values `amount`, `strikeAmount` and `state` to the display