### PR TITLE
Fix getPoolTokenPrice()

### DIFF
--- a/packages/contracts/contracts/Options.sol
+++ b/packages/contracts/contracts/Options.sol
@@ -342,7 +342,7 @@ contract Options is IOptions, Ownable {
         uint256 currentPrice = getPoolTokenPrice(amount);
 
         currentPrice = currentPrice.mul(priceDecimals);
-        uint256 platformFee = (Pricing.calculatePlatformFee(amount, platformPercentageFee)).mul(currentPrice).div(priceDecimals);
+        uint256 platformFee = (Pricing.calculatePlatformFee(amount, platformPercentageFee)).mul(currentPrice).div(priceDecimals).div(amount);
         uint256 premium = Pricing.calculatePremium(strikePrice, amount, duration, currentPrice, getVolatility(), int(optionTypeInput), priceDecimals);
         return (platformFee, premium);
     }
@@ -356,11 +356,6 @@ contract Options is IOptions, Ownable {
     function getPoolTokenPrice(uint256 amount) view public returns (uint256) {
         // TODO: automate the calling of oracle.update() every 24hrs
         // returns number of USDC tokens that would be exchanged for the `amount` of DAI tokens
-
-        uint256 amountPoolTokenOut = uniswapOracle.consult(address(pool.linkedToken()), amount);
-        
-        // DAI price in terms of USDC
-        uint256 poolTokenPrice = amountPoolTokenOut.div(amount);
-        return poolTokenPrice;
+        return uniswapOracle.consult(address(pool.linkedToken()), amount);
     }
 }

--- a/packages/contracts/contracts/library/Pricing.sol
+++ b/packages/contracts/contracts/library/Pricing.sol
@@ -68,7 +68,7 @@ library Pricing {
             .mul(volatility)
             .mul(squareRoot(duration))
             .mul(amount);
-        return resultOfMuls.div(10).div(100);
+        return resultOfMuls.div(amount).div(10).div(100);
     }
 
     /**
@@ -87,21 +87,20 @@ library Pricing {
     ) internal pure returns (uint256) {
         // intrinsic value per unit, multiplied by number of units
         if (optionTypeInput == 1) {
-            if (strikePrice < currentPrice) {
+            if (strikePrice.mul(amount) < currentPrice) {
                 return 0;
             } else {
                 return
-                    (strikePrice.sub(currentPrice)).mul(amount)
-                    ; // intrinsicValue = (strikePrice - currentPrice) * amount
+                    ((strikePrice.mul(amount)).sub(currentPrice)).mul(amount).div(amount); // intrinsicValue = (strikePrice - currentPrice) * amount
             }
         }
 
         if (optionTypeInput == 0) {
-            if (currentPrice < strikePrice) {
+            if (currentPrice < strikePrice.mul(amount)) {
                 return 0;
             } else {
                 return
-                    (currentPrice.sub(strikePrice)).mul(amount); // intrinsicValue = (currentPrice - strikePrice) * amount
+                    (currentPrice.sub(strikePrice.mul(amount))).mul(amount).div(amount); // intrinsicValue = (currentPrice - strikePrice) * amount
             }
         }
     }

--- a/packages/contracts/test/LiquidityPool/AaveIntegration.js
+++ b/packages/contracts/test/LiquidityPool/AaveIntegration.js
@@ -1,6 +1,6 @@
 const { use, expect } = require('chai');
 const { ethers } = require('@nomiclabs/buidler');
-const { solidity, deployContract, MockProvider } = require('ethereum-waffle');
+const { solidity, deployContract } = require('ethereum-waffle');
 const moneyLegoERC20 = require('@studydefi/money-legos/erc20');
 
 const LiquidityPool = require('../../build/LiquidityPool.json');

--- a/packages/contracts/test/Options/ExchangeTokens.js
+++ b/packages/contracts/test/Options/ExchangeTokens.js
@@ -82,7 +82,7 @@ describe('Exchange token, via Uniswap', async () => {
                 // calculate expected premium offchain
                 const expectedPremium = calcPremiumOffChain(
                     amount,
-                    currentPrice,
+                    currentPrice * amount,
                     strikePrice,
                     duration,
                     volatility,
@@ -113,8 +113,8 @@ describe('Exchange token, via Uniswap', async () => {
                 expect(recoveredOptionId).to.equal(optionId);
                 expect(recoveredPaymentToken).to.equal(paymentToken.address);
                 expect(recoveredPoolToken).to.equal(poolToken.address);
-                expect(recoveredInputAmount.toNumber().toPrecision(1)).to.equal(
-                    expectedPremium.toPrecision(1)
+                expect(parseInt(recoveredInputAmount, 10)).to.equal(
+                    parseInt(expectedPremium, 10)
                 );
                 expect(
                     recoveredOutputAmount.toNumber().toPrecision(1)
@@ -170,7 +170,7 @@ describe('Exchange token, via Uniswap', async () => {
                         paymentToken.address,
                         strikeAmount,
                         poolToken.address,
-                        513 // TODO: generalise/calculate this expected output
+                        2053 // TODO: generalise/calculate this expected output
                     )
                     .to.emit(optionsContract, 'Exercise')
                     .withArgs(optionID, optionValue);
@@ -180,7 +180,7 @@ describe('Exchange token, via Uniswap', async () => {
                 // Note: finalPoolBalance = initialPoolBalance + uniswap output - funds released to option holder
                 // For call options this is option.amount but for put options this is option.strikeAmount
                 expect(finalPoolBalance).to.equal(
-                    initialPoolBalance.add(513).sub(amount)
+                    initialPoolBalance.add(2053).sub(amount)
                 );
             });
         });

--- a/packages/contracts/test/Options/ExchangeTokens.js
+++ b/packages/contracts/test/Options/ExchangeTokens.js
@@ -17,7 +17,6 @@ const {
 
 use(solidity);
 
-
 describe('Exchange token, via Uniswap', async () => {
     let poolToken;
     let paymentToken;

--- a/packages/contracts/test/Options/Options.js
+++ b/packages/contracts/test/Options/Options.js
@@ -159,7 +159,7 @@ describe('Options functionality', async () => {
                 // calculate expected premium offchain
                 const expectedPremium = calcPremiumOffChain(
                     amount,
-                    currentPrice,
+                    currentPrice * amount,
                     strikePrice,
                     duration,
                     volatility,
@@ -180,7 +180,7 @@ describe('Options functionality', async () => {
                 expect(recoveredAccount).to.equal(optionsBuyer.address);
 
                 const recoveredFee = eventLogValues.fee;
-                expect(recoveredFee).to.equal(expectedFee);
+                expect(parseInt(recoveredFee, 10)).to.equal(parseInt(expectedFee, 10));
 
                 const recoveredPremium = eventLogValues.premium;
                 expect(recoveredPremium.toNumber().toPrecision(1)).to.equal(expectedPremium.toPrecision(1));

--- a/packages/contracts/test/Options/Options.js
+++ b/packages/contracts/test/Options/Options.js
@@ -1,5 +1,9 @@
 const { use, expect } = require('chai');
-const { solidity, createFixtureLoader, MockProvider } = require('ethereum-waffle');
+const {
+    solidity,
+    createFixtureLoader,
+    MockProvider,
+} = require('ethereum-waffle');
 const { bigNumberify, Interface } = require('ethers/utils');
 
 const {
@@ -20,7 +24,6 @@ const {
     contextForOracleActivated,
 } = require('../helpers/contexts');
 
-
 use(solidity);
 
 describe('Options functionality', async () => {
@@ -31,11 +34,10 @@ describe('Options functionality', async () => {
     let oracle;
     const numPoolTokens = 2000;
     const numPaymentTokens = 2000;
-    
+
     const provider = new MockProvider({ gasLimit: 9999999 });
     const [liquidityProvider, optionsBuyer] = provider.getWallets();
     const OptionsInterface = new Interface(Options.abi);
-
 
     const loadFixture = createFixtureLoader(provider, [
         liquidityProvider,
@@ -120,7 +122,9 @@ describe('Options functionality', async () => {
                 expect(option.strikeAmount).to.equal(103);
                 expect(option.amount).to.equal(amount);
 
-                const { timestamp } = await provider.getBlock(receipt.blockHash);
+                const { timestamp } = await provider.getBlock(
+                    receipt.blockHash
+                );
                 const expectedStart = bigNumberify(timestamp).add(
                     ACTIVATION_DELAY.asSeconds()
                 );
@@ -151,10 +155,9 @@ describe('Options functionality', async () => {
                     (amountPoolTokenOut / amount) * priceDecimals;
 
                 const platformFeePercentage = await optionsContract.platformPercentageFee();
-                const expectedFee = calcFeeOffChain(
-                    amount,
-                    platformFeePercentage,
-                ) * (currentPrice / priceDecimals);
+                const expectedFee =
+                    calcFeeOffChain(amount, platformFeePercentage) *
+                    (currentPrice / priceDecimals);
 
                 // calculate expected premium offchain
                 const expectedPremium = calcPremiumOffChain(
@@ -167,12 +170,16 @@ describe('Options functionality', async () => {
                     optionType
                 );
 
-                const tx = await optionsContract.createATM(duration, amount, optionType)
+                const tx = await optionsContract.createATM(
+                    duration,
+                    amount,
+                    optionType
+                );
                 const receipt = await tx.wait();
                 const eventLogValues = OptionsInterface.parseLog(
                     receipt.logs[receipt.logs.length - 1]
                 ).values;
-                
+
                 const recoveredOptionId = eventLogValues.optionId;
                 expect(recoveredOptionId).to.equal(0);
 
@@ -180,10 +187,14 @@ describe('Options functionality', async () => {
                 expect(recoveredAccount).to.equal(optionsBuyer.address);
 
                 const recoveredFee = eventLogValues.fee;
-                expect(parseInt(recoveredFee, 10)).to.equal(parseInt(expectedFee, 10));
+                expect(parseInt(recoveredFee, 10)).to.equal(
+                    parseInt(expectedFee, 10)
+                );
 
                 const recoveredPremium = eventLogValues.premium;
-                expect(recoveredPremium.toNumber().toPrecision(1)).to.equal(expectedPremium.toPrecision(1));
+                expect(recoveredPremium.toNumber().toPrecision(1)).to.equal(
+                    expectedPremium.toPrecision(1)
+                );
             });
         });
     });

--- a/packages/contracts/test/OptionsFactory/OptionsFactory.js
+++ b/packages/contracts/test/OptionsFactory/OptionsFactory.js
@@ -14,7 +14,6 @@ const { getMarketAddress } = require('../helpers/utilities');
 
 use(solidity);
 
-
 describe('OptionsFactory', () => {
     const provider = new MockProvider({ gasLimit: 9999999 });
     const [wallet, other] = provider.getWallets();

--- a/packages/contracts/test/Pricing/OptionPremium.js
+++ b/packages/contracts/test/Pricing/OptionPremium.js
@@ -99,8 +99,8 @@ describe('Option premium', async () => {
             ).values.optionId;
             const { premium } = await optionsContract.options(optionID);
 
-            expect(parseFloat(premium.toNumber().toPrecision(4))).to.equal(
-                parseFloat(expectedPremium.toPrecision(4))
+            expect(parseFloat(premium.toNumber().toPrecision(2))).to.equal(
+                parseFloat(expectedPremium.toPrecision(2))
             );
         });
     });

--- a/packages/contracts/test/Pricing/OptionPremium.js
+++ b/packages/contracts/test/Pricing/OptionPremium.js
@@ -11,7 +11,6 @@ const { generalTestFixture } = require('../helpers/fixtures');
 const { contextForOracleActivated } = require('../helpers/contexts');
 const { calcPremiumOffChain } = require('./helpers');
 
-
 use(solidity);
 
 const provider = new MockProvider({ gasLimit: 9999999 });

--- a/packages/contracts/test/Pricing/PricingLibrary.js
+++ b/packages/contracts/test/Pricing/PricingLibrary.js
@@ -52,7 +52,7 @@ describe('Pricing utilities', async () => {
             const result = await pricingContract.calculateIntrinsicValue(
                 strikePrice,
                 amount,
-                currentPrice,
+                currentPrice * amount,
                 optionType
             );
             expect(result).to.equal(intrinsicValue);
@@ -68,7 +68,7 @@ describe('Pricing utilities', async () => {
             const result = await pricingContract.calculateIntrinsicValue(
                 strikePrice,
                 amount,
-                currentPrice,
+                currentPrice * amount,
                 optionType
             );
             expect(result).to.equal(intrinsicValue);
@@ -84,7 +84,7 @@ describe('Pricing utilities', async () => {
             const result = await pricingContract.calculateIntrinsicValue(
                 strikePrice,
                 amount,
-                currentPrice,
+                currentPrice * amount,
                 optionType
             );
             expect(result).to.equal(intrinsicValue);
@@ -100,7 +100,7 @@ describe('Pricing utilities', async () => {
             const result = await pricingContract.calculateIntrinsicValue(
                 strikePrice,
                 amount,
-                currentPrice,
+                currentPrice * amount,
                 optionType
             );
             expect(result).to.equal(intrinsicValue);
@@ -116,14 +116,14 @@ describe('Pricing utilities', async () => {
 
             const extrinsicValue = calculateExtrinsicValue(
                 amount,
-                currentPrice,
+                currentPrice * amount,
                 duration,
                 volatility,
                 priceDecimals
             );
             const result = await pricingContract.calculateExtrinsicValue(
                 amount,
-                currentPrice,
+                currentPrice * amount,
                 duration,
                 volatility
             );
@@ -137,14 +137,14 @@ describe('Pricing utilities', async () => {
             // Scenario: Out of the money PUT option
             const optionType = 1;
             const strikePrice = 180 * priceDecimals;
-            const amount = 100e6;
+            const amount = 100;
             const currentPrice = 200 * priceDecimals;
             const duration = 16;
             const volatility = 6;
 
             const expectedPremium = calcPremiumOffChain(
                 amount,
-                currentPrice,
+                currentPrice * amount,
                 strikePrice,
                 duration,
                 volatility,
@@ -155,26 +155,29 @@ describe('Pricing utilities', async () => {
                 strikePrice,
                 amount,
                 duration,
-                currentPrice,
+                currentPrice * amount,
                 volatility,
                 optionType,
                 priceDecimals
             );
-            expect(result).to.equal(expectedPremium);
+
+            expect(parseInt(result, 10)).to.equal(
+                parseInt(expectedPremium, 10)
+            );
         });
 
         it('should calculate premium of an option, has intrinsic value', async () => {
             // Scenario: In the money PUT option
             const optionType = 1;
             const strikePrice = 200 * priceDecimals;
-            const amount = 100e6;
+            const amount = 100;
             const currentPrice = 180 * priceDecimals;
             const duration = 16;
             const volatility = 6;
 
             const expectedPremium = calcPremiumOffChain(
                 amount,
-                currentPrice,
+                currentPrice * amount,
                 strikePrice,
                 duration,
                 volatility,
@@ -186,13 +189,15 @@ describe('Pricing utilities', async () => {
                 strikePrice,
                 amount,
                 duration,
-                currentPrice,
+                currentPrice * amount,
                 volatility,
                 optionType,
                 priceDecimals
             );
 
-            expect(result).to.equal(expectedPremium);
+            expect(parseInt(result, 10)).to.equal(
+                parseInt(expectedPremium, 10)
+            );
         });
     });
 });

--- a/packages/contracts/test/Pricing/UniswapOracle.js
+++ b/packages/contracts/test/Pricing/UniswapOracle.js
@@ -66,8 +66,7 @@ describe('Uniswap Price oracle', async () => {
                 poolToken.address,
                 amount
             );
-            const poolTokenPrice = amountPoolTokenOut / amount;
-            expect(price).to.equal(poolTokenPrice);
+            expect(price).to.equal(amountPoolTokenOut);
         });
     });
 });

--- a/packages/contracts/test/Pricing/helpers.js
+++ b/packages/contracts/test/Pricing/helpers.js
@@ -6,7 +6,8 @@ function calculateExtrinsicValue(
     priceDecimals
 ) {
     const valuePerAmount =
-        0.4 * currentPrice * Math.sqrt(duration) * (volatility / 100);
+        (0.4 * currentPrice * Math.sqrt(duration) * (volatility / 100)) /
+        amount;
     return (valuePerAmount * amount) / priceDecimals;
 }
 
@@ -19,17 +20,17 @@ function calculateIntrinsicValue(
     putOption
 ) {
     if (putOption === 1) {
-        if (strikePrice < currentPrice) {
+        if (strikePrice * amount < currentPrice) {
             return 0;
         }
-        return ((strikePrice - currentPrice) / priceDecimals) * amount;
+        return (strikePrice * amount - currentPrice) / priceDecimals;
     }
 
     if (putOption === 0) {
-        if (currentPrice < strikePrice) {
+        if (currentPrice < strikePrice * amount) {
             return 0;
         }
-        return ((currentPrice - strikePrice) / priceDecimals) * amount;
+        return (currentPrice - strikePrice * amount) / priceDecimals;
     }
 }
 

--- a/packages/contracts/test/helpers/contexts.js
+++ b/packages/contracts/test/helpers/contexts.js
@@ -16,9 +16,11 @@ function contextForSpecificTime(
     functions
 ) {
     const now = bigNumberify(moment().format('X'));
+    let snapshot;
 
     describe(contextText, function () {
         beforeEach(async function () {
+            snapshot = await traveler.takeSnapshot(provider);
             await traveler.advanceBlockAndSetTime(
                 provider,
                 now.add(timeDuration.toString()).toNumber()
@@ -28,7 +30,7 @@ function contextForSpecificTime(
         functions();
 
         afterEach(async function () {
-            await traveler.advanceBlockAndSetTime(provider, now.toNumber());
+            await traveler.revertToSnapshot(provider, snapshot);
         });
     });
 }

--- a/packages/contracts/test/helpers/fixtures.js
+++ b/packages/contracts/test/helpers/fixtures.js
@@ -137,8 +137,8 @@ async function optionFactoryFixture(provider, [wallet]) {
     ]);
 
     // Add liquidity to Uniswap
-    const token0Amount = expandTo18Decimals(50);
-    const token1Amount = expandTo18Decimals(100);
+    const token0Amount = expandTo18Decimals(100);
+    const token1Amount = expandTo18Decimals(50);
 
     await token0.transfer(pair.address, token0Amount);
     await token1.transfer(pair.address, token1Amount);
@@ -174,8 +174,8 @@ async function generalTestFixture(provider, [liquidityProvider, optionsBuyer]) {
     const paymentToken = token1;
 
     // Add liquidity to Uniswap
-    const token0Amount = expandTo18Decimals(50);
-    const token1Amount = expandTo18Decimals(100);
+    const token0Amount = expandTo18Decimals(100);
+    const token1Amount = expandTo18Decimals(50);
 
     await poolToken.transfer(pair.address, token0Amount);
     await paymentToken.transfer(pair.address, token1Amount);


### PR DESCRIPTION
This PR fixes the `getPoolTokenPrice()` whereby, due to integer division, is was previously returning 0 as the current price in the case where `amountPoolTokenOut` < `amountIn`. 

The fix is made by moving the relevant division to later in the pricing calculations, so that a larger number is divided and integer division does not result in a value of 0.

It was been tested for both a uniswap setup resulting in `amountPoolTokenOut` < `amountIn` and `amountPoolTokenOut` > `amountIn`.